### PR TITLE
New attributes for vCard: work email, work and home fax, pager

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ vCard.role = 'Software Development';
 //set other phone numbers
 vCard.homePhone = '312-555-1313';
 vCard.cellPhone = '312-555-1414';
+vCard.pagerPhone = '312-555-1515';
+
+// set fax/ facsimile numbers
+vCard.homeFax = '312-555-1616';
+vCard.workFax = '312-555-1717';
+
+// set email addresses
+vCard.email = 'e.nesser@emailhost.tld';
+vCard.workEmail = 'e.nesser@acme-corporation.tld';
 
 //set logo of organization or personal logo (also supports embedding, see above)
 vCard.logo.attachFromUrl('https://avatars2.githubusercontent.com/u/5659221?v=3&s=460', 'JPEG');

--- a/index.js
+++ b/index.js
@@ -119,10 +119,16 @@ var vCard = (function () {
         cellPhone: '',
 
         /**
-         * The address for electronic mail communication
+         * The address for private electronic mail communication
          * @type {String}
          */
         email: '',
+
+        /**
+         * The address for work-related electronic mail communication
+         * @type {String}
+         */
+        workEmail: '',
 
         /**
          * First name

--- a/index.js
+++ b/index.js
@@ -119,6 +119,12 @@ var vCard = (function () {
         cellPhone: '',
 
         /**
+         * Other cell phone number or pager
+         * @type {String}
+         */
+        pagerPhone: '',
+
+        /**
          * The address for private electronic mail communication
          * @type {String}
          */
@@ -159,6 +165,12 @@ var vCard = (function () {
          * @type {String}
          */
         homePhone: '',
+
+        /**
+         * Home facsimile
+         * @type {String}
+         */
+        homeFax: '',
 
         /**
          * Last name
@@ -261,6 +273,12 @@ var vCard = (function () {
          * @type {String}
          */
         workPhone: '',
+
+        /**
+         * Work facsimile
+         * @type {String}
+         */
+        workFax: '',
 
         /**
          * vCard version

--- a/lib/vCardFormatter.js
+++ b/lib/vCardFormatter.js
@@ -191,6 +191,14 @@
                 }
             }
 
+            if (vCard.pagerPhone) {
+                if (majorVersion >= 4) {
+                    formattedVCardString += 'TEL;VALUE=uri;TYPE="pager,cell":tel:' + e(vCard.pagerPhone) + nl();
+                } else {
+                    formattedVCardString += 'TEL;TYPE=PAGER:' + e(vCard.pagerPhone) + nl();
+                }
+            }
+
             if (vCard.homePhone) {
                 if (majorVersion >= 4) {
                     formattedVCardString += 'TEL;VALUE=uri;TYPE="voice,home":tel:' + e(vCard.homePhone) + nl();
@@ -205,6 +213,24 @@
 
                 } else {
                     formattedVCardString += 'TEL;TYPE=WORK,VOICE:' + e(vCard.workPhone) + nl();
+                }
+            }
+
+            if (vCard.homeFax) {
+                if (majorVersion >= 4) {
+                    formattedVCardString += 'TEL;VALUE=uri;TYPE="fax,home":tel:' + e(vCard.homeFax) + nl();
+
+                } else {
+                    formattedVCardString += 'TEL;TYPE=HOME,FAX:' + e(vCard.homeFax) + nl();
+                }
+            }
+
+            if (vCard.workFax) {
+                if (majorVersion >= 4) {
+                    formattedVCardString += 'TEL;VALUE=uri;TYPE="fax,work":tel:' + e(vCard.workFax) + nl();
+
+                } else {
+                    formattedVCardString += 'TEL;TYPE=WORK,FAX:' + e(vCard.workFax) + nl();
                 }
             }
 

--- a/lib/vCardFormatter.js
+++ b/lib/vCardFormatter.js
@@ -157,9 +157,21 @@
 
             if (vCard.email) {
                 if (majorVersion >= 4) {
-                    formattedVCardString += 'EMAIL' + encodingPrefix + ':' + e(vCard.email) + nl();
+                    formattedVCardString += 'EMAIL' + encodingPrefix + ';type=HOME:' + e(vCard.email) + nl();
+                } else if (majorVersion >= 3 && majorVersion < 4) {
+                    formattedVCardString += 'EMAIL' + encodingPrefix + ';type=HOME,INTERNET:' + e(vCard.email) + nl();
                 } else {
-                    formattedVCardString += 'EMAIL' + encodingPrefix + ';PREF;INTERNET:' + e(vCard.email) + nl();
+                    formattedVCardString += 'EMAIL' + encodingPrefix + ';HOME;INTERNET:' + e(vCard.email) + nl();
+                }
+            }
+
+            if (vCard.workEmail) {
+                if (majorVersion >= 4) {
+                    formattedVCardString += 'EMAIL' + encodingPrefix + ';type=WORK:' + e(vCard.workEmail) + nl();
+                } else if (majorVersion >= 3 && majorVersion < 4) {
+                    formattedVCardString += 'EMAIL' + encodingPrefix + ';type=WORK,INTERNET:' + e(vCard.workEmail) + nl();
+                } else {
+                    formattedVCardString += 'EMAIL' + encodingPrefix + ';WORK;INTERNET:' + e(vCard.workEmail) + nl();
                 }
             }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -27,6 +27,7 @@ describe('vCard', function() {
     testCard.title = 'Crash Test Dummy';
     testCard.role = 'Crash Testing';
     testCard.email = 'john.doe@testmail';
+    testCard.workEmail = 'john.doe@workmail';
     testCard.url = 'http://johndoe';
     testCard.workUrl = 'http://acemecompany/johndoe';
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -22,6 +22,9 @@ describe('vCard', function() {
     testCard.workPhone = '312-555-1212';
     testCard.homePhone = '312-555-1313';
     testCard.cellPhone = '312-555-1414';
+    testCard.pagerPhone = '312-555-1515';
+    testCard.homeFax = '312-555-1616';
+    testCard.workFax = '312-555-1717';
     testCard.birthday = new Date();
     testCard.anniversary = new Date();
     testCard.title = 'Crash Test Dummy';


### PR DESCRIPTION
I added the attributes `vCard.pagerPhone`, `vCard.homeFax`, `vCard.workFax` and `vCard.workEmail` as I need these attributes for a project. I added them to the parser, the prototype and the full example in the readme. 

Tests are passing, I tested the formatting for vcard version `2.1`, `3.0` and `4.0` for compatibility with MacOS and Microsoft Outlook 2010.