### PR TITLE
Removed encodingPrefix from X-SOCIALPROFILE

### DIFF
--- a/lib/vCardFormatter.js
+++ b/lib/vCardFormatter.js
@@ -375,7 +375,7 @@
 				for (var key in vCard.socialUrls) {
 					if (vCard.socialUrls.hasOwnProperty(key) &&
 						vCard.socialUrls[key]) {
-						formattedVCardString += 'X-SOCIALPROFILE' + encodingPrefix + ';TYPE=' + key + ':' + e(vCard.socialUrls[key]) + nl();
+						formattedVCardString += 'X-SOCIALPROFILE;TYPE=' + key + ':' + e(vCard.socialUrls[key]) + nl();
 					}
 				}
 			}

--- a/test/testCard.vcf
+++ b/test/testCard.vcf
@@ -27,11 +27,11 @@ ORG;CHARSET=UTF-8:ACME Corporation
 URL;CHARSET=UTF-8:http://johndoe
 URL;type=WORK;CHARSET=UTF-8:http://acemecompany/johndoe
 NOTE;CHARSET=UTF-8:John Doe's \nnotes\;\,
-X-SOCIALPROFILE;CHARSET=UTF-8;TYPE=facebook:https://facebook/johndoe
-X-SOCIALPROFILE;CHARSET=UTF-8;TYPE=linkedIn:https://linkedin/johndoe
-X-SOCIALPROFILE;CHARSET=UTF-8;TYPE=twitter:https://twitter/johndoe
-X-SOCIALPROFILE;CHARSET=UTF-8;TYPE=flickr:https://flickr/johndoe
-X-SOCIALPROFILE;CHARSET=UTF-8;TYPE=custom:https://custom/johndoe
+X-SOCIALPROFILE;TYPE=facebook:https://facebook/johndoe
+X-SOCIALPROFILE;TYPE=linkedIn:https://linkedin/johndoe
+X-SOCIALPROFILE;TYPE=twitter:https://twitter/johndoe
+X-SOCIALPROFILE;TYPE=flickr:https://flickr/johndoe
+X-SOCIALPROFILE;TYPE=custom:https://custom/johndoe
 SOURCE;CHARSET=UTF-8:http://sourceurl
 REV:2019-01-04T20:18:50.127Z
 END:VCARD


### PR DESCRIPTION
Noticed that on Mac, adding encodingPrefix (which is not really required) shows strange things when importing a vcard: https://ibb.co/ChdBh7f
For some reason, it is however fixed after some time, probably because Google Contacts changes it and removes the encodingPrefix.

But after removing the charset, it seems to work fine from the first time.