### PR TITLE
is necessary use colon instead of semicolon in order to set the social networks correctly

### DIFF
--- a/lib/vCardFormatter.js
+++ b/lib/vCardFormatter.js
@@ -375,7 +375,7 @@
 				for (var key in vCard.socialUrls) {
 					if (vCard.socialUrls.hasOwnProperty(key) &&
 						vCard.socialUrls[key]) {
-						formattedVCardString += 'X-SOCIALPROFILE;TYPE=' + key + ':' + e(vCard.socialUrls[key]) + nl();
+						formattedVCardString += 'X-SOCIALPROFILE:TYPE=' + key + ':' + e(vCard.socialUrls[key]) + nl();
 					}
 				}
 			}
@@ -385,11 +385,11 @@
 			}
 
 			formattedVCardString += 'REV:' + (new Date()).toISOString() + nl();
-			
+
 			if (vCard.isOrganization) {
 				formattedVCardString += 'X-ABShowAs:COMPANY' + nl();
-			} 
-			
+			}
+
 			formattedVCardString += 'END:VCARD' + nl();
 			return formattedVCardString;
 		}


### PR DESCRIPTION
I have fixed the build of `X-SOCIALPROFILE`, using the semicolon the text `CHARSET-UTF8` appears in the social network property of the contact, so putting `colon` instead of the `semicolon` can solve this problem