### PR TITLE
multiple url for Android devices

### DIFF
--- a/lib/vCardFormatter.js
+++ b/lib/vCardFormatter.js
@@ -360,6 +360,10 @@
 			}
 
 			if (vCard.url) {
+        vCard.url.forEach((number) => {
+          formattedVCardString += 'URL'+ encodingPrefix + ':' + e(number) + nl();
+        });
+
 				formattedVCardString += 'URL' + encodingPrefix + ':' + e(vCard.url) + nl();
 			}
 
@@ -385,11 +389,11 @@
 			}
 
 			formattedVCardString += 'REV:' + (new Date()).toISOString() + nl();
-			
+
 			if (vCard.isOrganization) {
 				formattedVCardString += 'X-ABShowAs:COMPANY' + nl();
-			} 
-			
+			}
+
 			formattedVCardString += 'END:VCARD' + nl();
 			return formattedVCardString;
 		}


### PR DESCRIPTION
With this change, it is possible to add multiple URLs as social networks for Android devices, since these devices do not support the `X-SOCIAL PROFILE` property in their contacts.