### PR TITLE
fix: disable fs and path for browser usage (webpack 5 compatibility)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   "scripts": {
     "test": "mocha ./test/tests"
   },
+  "browser": {
+    "fs": false,
+    "path": false
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/enesser/vCards-js.git"


### PR DESCRIPTION
Webpack 5 does not provide nodejs module polyfill by default. This means importing vCards-js in a webpack 5 project does not work anymore. We can define the "browsers" property inside package.json to disable nodejs modules for browser usage.