### PR TITLE
Escape semicolons in the compound ORG value (RFC 6350 6.6.4)

### DIFF
--- a/lib/vCardFormatter.js
+++ b/lib/vCardFormatter.js
@@ -464,7 +464,7 @@
 				formattedVCardString += contentLine("ROLE", params, e(vCard.role));
 
 			if (vCard.organization)
-				formattedVCardString += contentLine("ORG", params, e(vCard.organization));
+				formattedVCardString += contentLine("ORG", params, ec(vCard.organization));
 
 			if (vCard.url)
 			{

--- a/test/tests.js
+++ b/test/tests.js
@@ -221,6 +221,22 @@ describe("vCard", function()
 			done();
 		});
 
+		it("should escape the semicolon in the compound ORG value (RFC 6350 6.6.4)", function(done)
+		{
+			// ORG is a compound property whose components are delimited by ";",
+			//   just like N and ADR. A semicolon inside an organization name is data
+			//   and must be escaped so it is not read as a component separator.
+			const orgCard = vCard();
+			orgCard.version = "3.0";
+			orgCard.organization = "ACME; Inc.";
+			const orgLines = splitVcardStringIntoOrderedContentLines(orgCard.getFormattedString());
+			const orgValue = getValueByFieldName("ORG", orgLines);
+
+			assert.ok(orgValue.indexOf("\\;") !== -1, "Expected an escaped semicolon in ORG: " + orgValue);
+			assert.ok(!/(?:^|[^\\]);/.test(orgValue), "Found an unescaped semicolon in ORG: " + orgValue);
+			done();
+		});
+
 		it("should format birthday as 2018-12-01 (ISO-8601 4.1.2.2 extended date format)", function(done)
 		{
 			const birthdayValue = getValueByFieldName("BDAY", v3Lines);


### PR DESCRIPTION
`ORG` is a compound property: its value is one or more components delimited by a semicolon (RFC 6350 6.6.4, `ORG-value = component *(";" component)`; same structure in RFC 2426 3.5.5). A semicolon that appears inside an organization name is data, so it must be escaped as `\;`. Otherwise a reader treats it as a component separator and splits the name into two units.

The formatter has two escapers: `e()` for plain text values and `ec()` for compound values (it adds `;` escaping on top of `e()`). The other two compound properties, `N` and `ADR`, already use `ec()`. `ORG` was left on `e()`, so a semicolon in an organization name is emitted raw:

```
ORG:ACME; Inc.     before
ORG:ACME\; Inc.    after
```

Fix: format `ORG` with `ec()`, the same escaper `N` and `ADR` use. Backslash, comma and newline escaping are unchanged (a name without a semicolon produces identical output, so the existing fixtures are unaffected). Added a test that sets an organization name containing a semicolon and checks the emitted value is escaped.

Note: two `should match a working vCard` tests already fail on `master` because the PHOTO base64 in the `v3`/`v4` fixtures is truncated. That is unrelated to this change, which only touches `ORG`.
